### PR TITLE
ci(frontend): add Docker build and push workflow (dev branch)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,52 @@
+# =============================================================================
+# Frontend (Next.js) image build & push to Docker Hub
+# =============================================================================
+# Branch -> tag mapping:
+#   dev  -> :dev    (deploy server polls and pulls this)
+#   main -> :latest
+#   any  -> :<sha>  (immutable reference, used for rollbacks)
+#
+# Required GitHub Secrets:
+#   DOCKERHUB_USERNAME
+#   DOCKERHUB_TOKEN
+# =============================================================================
+
+name: Build & Push Frontend
+
+on:
+  push:
+    branches: [main, dev]
+  workflow_dispatch:
+
+env:
+  IMAGE_NAME: ${{ secrets.DOCKERHUB_USERNAME }}/ifritah-web
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - id: meta
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=sha,prefix=
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=dev,enable=${{ github.ref == 'refs/heads/dev' }}
+
+      - uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
Adds a GitHub Actions workflow that builds the Next.js Dockerfile and pushes to Docker Hub on every push to `dev` (publishes `:dev`) or `main` (publishes `:latest`). Mirrors the backend workflow in `abdul-mohsen/ifritah-go`.

Branch -> tag:
- `dev`  -> `${DOCKERHUB_USERNAME}/ifritah-web:dev`  (auto-pulled by deployment server)
- `main` -> `${DOCKERHUB_USERNAME}/ifritah-web:latest`
- any push -> immutable `:<sha>` tag

**Required repo secrets** (need to be added before this can run):
- `DOCKERHUB_USERNAME`
- `DOCKERHUB_TOKEN` (Docker Hub PAT with Read & Write on the `ifritah-web` repo)

Verified locally: built the Dockerfile (node:25-alpine multi-stage), ran the resulting image, GET /login returned 200 (11.5 KB Next.js page).